### PR TITLE
[Change] OS used to test python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,16 @@ jobs:
   test:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
-        python:
-        - "3.7"  # oldest Python supported by PSF
-        - "3.11"  # newest Python that is stable
-        platform:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+          - python: "3.7"
+            platform: macos-latest
+        include:  # So run those legacy versions on Intel CPUs.
+          - python: "3.7"
+            platform: macos-13
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -92,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: {python-version: "3.11"}
+        with: {python-version: "3.10"}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}


### PR DESCRIPTION
# Description

The aim is to fix tests failing due to changes in the `macos-latest` GitHub actions runner: https://github.com/actions/setup-python/issues/856

# Proposed Changes

I changed the GitHub actions file following this example https://github.com/actions/runner-images/issues/9770#issuecomment-2085623315